### PR TITLE
Update resource group and cluster name in Azure Kubernetes Service workflow

### DIFF
--- a/.github/workflows/azure-kubernetes-service.yml
+++ b/.github/workflows/azure-kubernetes-service.yml
@@ -37,8 +37,8 @@ on:
 env:
   AZURE_CONTAINER_REGISTRY: 'acseshop1105023429'
   CONTAINER_NAME: 'productservice'
-  RESOURCE_GROUP: 'rg-eshop2'
-  CLUSTER_NAME: 'aks-eshop2'
+  RESOURCE_GROUP: 'rg-eshop'
+  CLUSTER_NAME: 'aks-eshop'
   DEPLOYMENT_MANIFEST_PATH: './dotnet-deploy/Product.yml'
   DOCKER_PATH: './dotnet-deploy/DockerfileProducts'
 


### PR DESCRIPTION
This pull request updates the resource group and cluster name in the Azure Kubernetes Service workflow. The previous values were 'rg-eshop2' and 'aks-eshop2', and they have been changed to 'rg-eshop' and 'aks-eshop' respectively. This change ensures that the workflow deploys to the correct resource group and cluster.